### PR TITLE
Updated to work with IIIF 1.1

### DIFF
--- a/www/tilesource-iiif.html
+++ b/www/tilesource-iiif.html
@@ -2,8 +2,8 @@
     example: iiif tile support
 </h2>
 <p>
-    The International Image Interoperability Format is formally described
-    <a href='http://library.stanford.edu/iiif/image-api/'>here</a>.
+    The latest version (1.1) of the International Image Interoperability Framework: Image API is formally described
+    <a href='http://www-sul.stanford.edu/iiif/image-api/1.1/'>here</a>.
 </p>
 <p>
     The IIIF API specifies a web service that returns an image in response to a standard HTTP or HTTPS request. 
@@ -53,16 +53,16 @@ OpenSeadragon({
     minZoomLevel:       1,
     defaultZoomLevel:   1,
     tileSources:   [{
-        "identifier":   "pudl0001/4609321/s42/00000001",   
-        "width":        2617,   
-        "height":       3600,   
-        "scale_factors": [1, 2, 3, 4, 5],   
-        "tile_width":   256,   
-        "tile_height":  256,   
-        "formats":      [ "jpg", "png" ],   
-        "qualities":    ["native", "bitonal", "grey", "color"],   
-        "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1",
-        "image_host":   "http://lorisimg.princeton.edu/loris"
+        "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+        "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2",
+        "formats": [ "jpg", "png", "gif" ],
+        "height": 3600,
+        "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+        "qualities": [ "native", "bitonal", "grey", "color" ],
+        "scale_factors": [ 1, 2, 4, 8, 16 ],
+        "tile_height": 256,
+        "tile_width": 256,
+        "width": 2617
     },
        ...
     ]
@@ -78,107 +78,77 @@ OpenSeadragon({
         minZoomLevel:       1,
         defaultZoomLevel:   1,
         tileSources:   [{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000001",   
-            "width":        2617,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+            "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2",
+            "formats": [ "jpg", "png", "gif" ],
+            "height": 3600,
+            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "qualities": [ "native", "bitonal", "grey", "color" ],
+            "scale_factors": [ 1, 2, 4, 8, 16 ],
+            "tile_height": 256,
+            "tile_width": 256,
+            "width": 2617
         },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000002",   
-            "width":        2547,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+            "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000002.jp2",
+            "formats": [ "jpg", "png", "gif" ],
+            "height": 3600,
+            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "qualities": [ "native", "bitonal", "grey", "color" ],
+            "scale_factors": [ 1, 2, 4, 8, 16 ],
+            "tile_height": 256,
+            "tile_width": 256,
+            "width": 2547
         },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000003",   
-            "width":        2694,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+            "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000003.jp2",
+            "formats": [ "jpg", "png", "gif" ],
+            "height": 3600,
+            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "qualities": [ "native", "bitonal", "grey", "color" ],
+            "scale_factors": [ 1, 2, 4, 8, 16 ],
+            "tile_height": 256,
+            "tile_width": 256,
+            "width": 2694
         },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000004",   
-            "width":        2717,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
-        },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000005",   
-            "width":        2694,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
-        },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000006",   
-            "width":        2717,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
-        },{
-            "image_host":     "http://lorisimg.princeton.edu/loris",
-            "identifier":   "pudl0001/4609321/s42/00000007",   
-            "width":        2694,   
-            "height":       3600,   
-            "scale_factors": [1, 2, 3, 4, 5],   
-            "tile_width":   256,   
-            "tile_height":  256,   
-            "formats":      [ "jpg", "png" ],   
-            "qualities":    ["native", "bitonal", "grey", "color"],   
-            "profile":      "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+            "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+            "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000004.jp2",
+            "formats": [ "jpg", "png", "gif" ],
+            "height": 3600,
+            "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+            "qualities": [ "native", "bitonal", "grey", "color" ],
+            "scale_factors": [ 1, 2, 4, 8, 16 ],
+            "tile_height": 256,
+            "tile_width": 256,
+            "width": 2717
         }]
     });
 </script>
 
 <div class="description">
-    <h3>XMLHTTPRequest for IIIF info.xml or info.json</h3>
-    <p>
-        The following example info.json and info.xml documents include
-        a property <code>image_host</code> which allows the info.json and info.xml
-        to be hosted from a different server than the images are served from.
+    <h3>XMLHTTPRequest for IIIF info.json</h3>
+    <p>Note: The following examples follows the IIIF Image API specification 
+        version 1.1. The older 1.0 XML and JSON syntaxes is also supported. 
     </p>
 </div>
 <div class="demoarea">
     <div class="demoheading">
-        Example XMLHTTPRequest for IIIF info (XML or JSON)
+        Example XMLHTTPRequest for IIIF info JSON
     </div>
-    <div id="example-xmlhttprequest-for-info-xml" 
+    <div id="example-xmlhttprequest-for-info-json" 
          class="openseadragon">
         <script type="text/javascript">
             OpenSeadragon({
-                id:            "example-xmlhttprequest-for-info-xml",
+                id:            "example-xmlhttprequest-for-info-json",
                 prefixUrl:     "/openseadragon/images/",
                 tileSources:   [
-                    "/example-images/loris/pudl0001/4609321/s42/00000003/info.json",
-                    "/example-images/loris/pudl0001/4609321/s42/00000004/info.xml"
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000002.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000003.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000004.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000005.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000006.jp2/info.json",
+                    "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000007.jp2/info.json"
                 ]
             });
         </script>
@@ -189,59 +159,33 @@ OpenSeadragon({
         </noscript>
     </div>
     <p>
-        Below is a sample IIIF info file formatted as XML.
+        Below is a sample IIIF info file.
     </p>
 <pre>
-&lt;?xml version="1.0" encoding="UTF-8"?>
-&lt;info xmlns="http://library.stanford.edu/iiif/image-api/ns/">
-    &lt;identifier>pudl0001/4609321/s42/00000004&lt;/identifier>
-    &lt;width>2717&lt;/width>
-    &lt;height>3600&lt;/height>
-    &lt;scale_factors>
-        &lt;scale_factor>1&lt;/scale_factor>
-        &lt;scale_factor>2&lt;/scale_factor>
-        &lt;scale_factor>3&lt;/scale_factor>
-        &lt;scale_factor>4&lt;/scale_factor>
-        &lt;scale_factor>5&lt;/scale_factor>
-    &lt;/scale_factors>
-    &lt;tile_width>256&lt;/tile_width>
-    &lt;tile_height>256&lt;/tile_height>
-    &lt;formats>
-        &lt;format>jpg&lt;/format>
-        &lt;format>png&lt;/format>
-    &lt;/formats>
-    &lt;qualities>
-        &lt;quality>native&lt;/quality>
-        &lt;quality>bitonal&lt;/quality>
-        &lt;quality>grey&lt;/quality>
-        &lt;quality>color&lt;/quality>
-    &lt;/qualities>
-    &lt;profile>http://library.stanford.edu/iiif/image-api/compliance.html#level1&lt;/profile>
-    &lt;image_host>http://lorisimg.princeton.edu/loris&lt;/image_host>
-&lt;/info></pre>
-    <p>
-        And the equivalent sample IIIF info file formatted as JSON.
-    </p>
-<pre>
-{  
-    "identifier" : "pudl0001/4609321/s42/00000003",
-    "width":        2694,   
-    "height":       3600,   
-    "scale_factors" : [1, 2, 3, 4, 5],   
-    "tile_width" : 256,   
-    "tile_height" : 256,   
-    "formats" : [ "jpg", "png" ],   
-    "qualities" : ["native", "bitonal", "grey", "color"],   
-    "profile" : "http://library.stanford.edu/iiif/image-api/compliance.html#level1",
-    "image_host": "http://lorisimg.princeton.edu/loris"
+{
+    "@context": "http://library.stanford.edu/iiif/image-api/1.1/context.json",
+    "@id": "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2",
+    "formats": [ "jpg","png","gif"],
+    "height": 3600,
+    "width": 2617,
+    "profile": "http://library.stanford.edu/iiif/image-api/1.1/compliance.html#level2",
+    "qualities": ["native","bitonal","grey","color"],
+    "scale_factors": [1,2,4,8,16],
+    "tile_height": 256,
+    "tile_width": 256
 }</pre>
 <pre>
 OpenSeadragon({
     ...
     tileSources:   [
-        "/example-images/loris/pudl0001/4609321/s42/00000003/info.json",
-        "/example-images/loris/pudl0001/4609321/s42/00000004/info.xml"
-    ],
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000001.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000002.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000003.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000004.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000005.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000006.jp2/info.json",
+        "http://libimages.princeton.edu/loris/pudl0001%2F4609321%2Fs42%2F00000007.jp2/info.json"
+    ]
     ...
 });</pre>
 </div>


### PR DESCRIPTION
see openseadragon/site-build#29

Sorry it took so long. Loris (my IIIF app) supports Access-Control-Allow-Origin, so the `XMLHTTPRequest` should work now, but of course this was the first time I'd tried it outside our domain :grin:. Everything should be in order now.
