### PR TITLE
Add Bower Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "images",
     "releases",
     "www",
-    ".gitignore",
     "Gruntfile.js",
     "README.md",
     "doc-conf.json",


### PR DESCRIPTION
This adds bower support for Open Seadragon. To finalize this, two steps are required to be executed by the repo owner:
- Unregister the old package using:
  
  `curl -X DELETE "https://bower.herokuapp.com/packages/OpenSeadragon?auth_token=TOKEN"`
  
  Detailed instructions: https://github.com/bower/bower/issues/120
- Register this new package using:
  
  `bower register OpenSeadragon git://github.com/openseadragon/site-build`

Discussion is here:
https://github.com/openseadragon/openseadragon/pull/340
