### PR TITLE
adds sourcemapurl to main bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "openseadragon"
   ],
   "description": "An open-source, web-based viewer for zoomable images, implemented in pure JavaScript.",
-  "main": "built-openseadragon/openseadragon/openseadragon.min.js",
+  "main": ["built-openseadragon/openseadragon/openseadragon.min.js", "built-openseadragon/openseadragon/openseadragon.min.js.map"],
   "keywords": [
     "zoom",
     "images",


### PR DESCRIPTION
Adds source map file to main in bower.json. Since this is referenced in `openseadragon.min.js` I would propose that it be included as a main file, per the bower definition.

"main string or array: The primary acting files necessary to use your package."

Build processes will strip out non main files and since it is referenced this could be a problem for some.
