### PR TITLE
Adding installations section to in-the-wild page

### DIFF
--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -222,6 +222,6 @@ Victoria and Albert Museum: Exhibition Road drawing scroll</a> (<a href="http://
 </ul>
 <h4>Installations</h4>
 <ul class="square-list">
-    <li><a href="http://deyoung.famsf.org/">de Young Museum; San Francisco</a></li>
-    <li><a href="https://thewadsworth.org/">Wadsworth Atheneum: Museum of Art; Hartford, Connecticut</a></li>
+    <li><a href="http://deyoung.famsf.org/">de Young Museum; San Francisco. Herbst Exhibition Galleries. 2015-2016</a></li>
+    <li><a href="https://thewadsworth.org/">Wadsworth Atheneum: Museum of Art; Hartford, Connecticut. Cabinets of Art &amp; Curiosity Gallery. 2015</a></li>
 </ul>

--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -220,3 +220,8 @@ Victoria and Albert Museum: Exhibition Road drawing scroll</a> (<a href="http://
     <li><a href="http://player.digirati.co.uk/">Wellcome Player</a></li>
     <li><a href="http://zoomable.ca/">Zoomable</a></li>
 </ul>
+<h4>Installations</h4>
+<ul class="square-list">
+    <li><a href="http://deyoung.famsf.org/">de Young Museum, San Francisco</a></li>
+    <li><a href="https://thewadsworth.org/">Wadsworth Atheneum: Museum of Art, Hartford Connecticut</a></li>
+</ul>

--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -222,6 +222,6 @@ Victoria and Albert Museum: Exhibition Road drawing scroll</a> (<a href="http://
 </ul>
 <h4>Installations</h4>
 <ul class="square-list">
-    <li><a href="http://deyoung.famsf.org/">de Young Museum, San Francisco</a></li>
-    <li><a href="https://thewadsworth.org/">Wadsworth Atheneum: Museum of Art, Hartford Connecticut</a></li>
+    <li><a href="http://deyoung.famsf.org/">de Young Museum; San Francisco</a></li>
+    <li><a href="https://thewadsworth.org/">Wadsworth Atheneum: Museum of Art; Hartford, Connecticut</a></li>
 </ul>


### PR DESCRIPTION
I linked to the museums main page as the articles provided in #118 didn't seem to have any information about OpenSeadragon specifically. I can add the articles in as an e.g.? 

The de Young museum link is also linked to the museum main page as the Twitter link you sent only had a picture of the installation from a personal Twitter account
