### PR TITLE
add link to OpenSeadragonPaperjsOverlay plugin

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -162,6 +162,7 @@
             <li><a href="https://github.com/picturae/OpenSeadragonZoomLevels">OpenSeadragonZoomLevels</a> allows restricting the image zoom to specific levels.</li>
             <li><a href="https://github.com/altert/OpenseadragonFabricjsOverlay">OpenSeadragonFabricjsOverlay</a> allows you to add Fabric.js canvas overlay that pans and zooms with OpenSeadragon viewer.</li>
             <li><a href="https://github.com/altert/OpenSeadragonCanvasOverlay">OpenSeadragonCanvasOverlay</a> allows you to add canvas overlay that pans and zooms with OpenSeadragon viewer.</li>
+            <li><a href="https://github.com/eriksjolund/OpenSeadragonPaperjsOverlay">OpenSeadragonPaperjsOverlay</a> allows you to add Paper.js canvas overlay that pans and zooms with OpenSeadragon viewer.</li>
         </ul>
     </li>
     <li>


### PR DESCRIPTION
I've forked https://github.com/altert/OpenseadragonFabricjsOverlay and modified it to support Paper.js instead of Fabric.js. This pull request adds https://github.com/eriksjolund/OpenSeadragonPaperjsOverlay to the list of OpenSeadragon plugins.