### PR TITLE
Add link to OpenseadragonGuides plugin

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -168,6 +168,7 @@
             <li><a href="https://github.com/Emigre/openseadragon-annotations">OpenSeadragonAnnotations</a> allows you to draw in a SVG overlay that scales with the image. Useful to annotate and highlight regions of an image.</li>
             <li><a href="https://github.com/thejohnhoffer/viaWebGL">OpenSeadragonGL</a> allows you to run WebGL shaders on all tiles in OpenSeadragon.</li>
             <li><a href="https://github.com/KTGLeiden/Openseadragon-screenshot">OpenSeadragonScreenshot</a> allows you to make a screenshot of your viewport, with optional magnification.</li>
+            <li><a href="https://github.com/picturae/OpenSeadragonGuides">OpenSeadragonGuides</a> allows you to add horizontal and vertical guidelines to the Openseadragon viewer.</li>
         </ul>
     </li>
     <li>


### PR DESCRIPTION
Hi,
I've added a link to a plugin for adding horizontal and vertical guidelines to the Openseadragon Viewer.