### PR TITLE
`process_jp2.py` was deprecated to `process.py`

### DIFF
--- a/www/creating-zooming-images.html
+++ b/www/creating-zooming-images.html
@@ -120,7 +120,7 @@
         <td>
             C++ library to encode or decode JPEG 2000 images
             <br><br>
-            example of a batch convert script: <a href="https://github.com/DDMAL/diva.js/blob/master/source/processing/process_jp2.py">process_jp2.py</a> (Diva.js project)
+            example of a batch convert script: <a href="https://github.com/DDMAL/diva.js/blob/master/legacy/process.py">process.py</a> (Diva.js project)
         </td>
         <td>
             <a href="/examples/tilesource-iiif/">IIIF</a><br/>(requires a IIIF-compliant image server with JPEG 2000 support, like <a href="https://github.com/pulibrary/loris">Loris</a>; see also <a href="http://iiif.io">iiif.io</a> for more details)


### PR DESCRIPTION
The commit: https://github.com/DDMAL/diva.js/commit/f0dd51f08c4b3c070725ac39e4de21a528c6818f
New `process.py` file is now located at https://github.com/DDMAL/diva.js/blob/master/legacy/process.py