### PR TITLE
Add link to Lunch

### DIFF
--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -326,6 +326,7 @@
 
     <li><a href="http://ignaciobello.com.ar/infografia_21_personajes_que_mas_progresaron.html">Ignacio Bello's "21 Personajes Que M&aacute;s Progresaron"</a></li>
     <li><a href="http://www.monticello.org/mulberry-row/places/phase-i">Landscape of Slavery: Mulberry Row at Monticello</a></li>
+    <li><a href="http://labs.statsbiblioteket.dk/juxta/lunch/">Lunch</a></li>
     <li><a href="https://mapofmetal.com/">Map of Metal</a></li>
     <li><a href="http://beehivecollective.org/posterViewer/?poster=mr">Mesoam&eacute;rica Resiste, Beehive Design Collective</a></li>
     <li><a href="https://www.nytimes.com/interactive/2017/01/20/us/politics/trump-inauguration-photo-zoomer.html">New York Times' Who's Who of President Trump's Inauguration</a></li>


### PR DESCRIPTION
The [Lunch](http://labs.statsbiblioteket.dk/juxta/lunch/) installation superimposes one OpenSeadragon on another, creating a loupe/x-ray/spyglass effect of lunch trays before & after lunch