### PR TITLE
Added link to OpenSeadragonAnnotorious plugin

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -159,6 +159,7 @@
         <ul class="square-list">
             <li><a href="https://github.com/openseadragon/bookmark-url">Bookmark URL</a> updates the page URL with the current zoom/pan.</li>
             <li><a href="https://github.com/Emigre/openseadragon-annotations">OpenSeadragonAnnotations</a> allows you to draw in a SVG overlay that scales with the image. Useful to annotate and highlight regions of an image.</li>
+            <li><a href="https://github.com/recogito/annotorious-openseadragon">OpenSeadragonAnnotorious</a> enables creation and display of annotations in W3C Web Annotation format.</li>
             <li><a href="https://github.com/altert/OpenSeadragonCanvasOverlay">OpenSeadragonCanvasOverlay</a> allows you to add canvas overlay that pans and zooms with OpenSeadragon viewer.</li>
             <li><a href="https://github.com/joshua-gould/OpenSeadragonCanvasOverlayHd">OpenSeadragonCanvasOverlayHd</a> OpenSeadragonCanvasOverlayHd</a> allows you to add a canvas overlay that renders nicely on retina displays, pans and zooms with OpenSeadragon viewer, and supports multi-images.</li>
             <li><a href="https://github.com/harshalitalele/OpenSeadragonDraggableNavigator/">OpenSeadragonDraggableNavigator</a> allows you to make navigator draggable over the OpenSeadragon viewer.</li>


### PR DESCRIPTION
The OpenSeadragon Annotorious annotation plugin is now available in a first functional version. See https://github.com/recogito/annotorious-openseadragon 