### PR TITLE
Add NIH's COVID image repository to `/in-the-wild.html`

### DIFF
--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -274,6 +274,7 @@
     <li><a href="http://www.allencell.org/deep-cell-zoom.html">Allen Cell Explorer</a></li>
     <li><a href="https://www.doc.ic.ac.uk/~dmcginn/adjmat.html">Bitcoin Blockchain Explorer</a></li>
     <li><a href="http://cancer.digitalslidearchive.net/">Cancer Digital Slide Archive</a></li>
+    <li><a href="https://covid19pathology.nih.gov/">COVID Digital Pathology Repository</a></li>
     <li>
         <a href="http://feistyphoton.org/">Feisty Photon - Astrophotography by Darryn Lavery</a>
         <ul>


### PR DESCRIPTION
NIH has made a [publicly available digital repository of tissue samples](https://covid19pathology.nih.gov/) from patients with COVID/SARS/MERS. Its image viewers use OSD.
To see the OSD use, click 'View the DPR', enter an email, login with the pre-filled creds, navigate thru the folders, and open any image.

full disclosure-- this is a stripped-down and public deployment of my team's product  =)