### PR TITLE
add types support to installation instructions

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -250,6 +250,21 @@
     available on GitHub</a>.
 </p>
 
+<ul>
+    <li>
+        <h3 id="types">Types support</h3>
+        <p>
+            Type definitions for OpenSeadragon can be installed from <a href="https://www.npmjs.com/package/@types/openseadragon">npm</a>.
+            <p>
+                <pre>npm install @types/openseadragon</pre>
+            </p>
+            <p>
+                Note: these are un-official type definitions that are mantained by the <a href="https://github.com/DefinitelyTyped/DefinitelyTyped">DefinitelyTyped</a> community.
+            </p>
+        </p>
+    </li>
+</ul>
+
 
 <h2 id='api-documentation'>API Documentation</h2>
 <p>Available on our <a href="/docs/">documentation pages</a>.</p>


### PR DESCRIPTION
I added a section to the installation instructions mentioning the @types/openseadragon package that can be installed to add the community-mantained openseadragon types.

@iangilman suggested this a while back (https://github.com/openseadragon/openseadragon/issues/1628#issuecomment-624903758) but I had not submitted the type definitions to DefinitelyTyped yet.

I hope this is useful for people using typescript!