### PR TITLE
Docs: Update third party URLs

### DIFF
--- a/www/creating-zooming-images.html
+++ b/www/creating-zooming-images.html
@@ -13,7 +13,7 @@
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
     <tr>
-        <td><a href="http://search.cpan.org/~drrho/Graphics-DZI-0.05/script/deepzoom">deepzoom</a></td>
+        <td><a href="https://metacpan.org/pod/release/DRRHO/Graphics-DZI-0.05/script/deepzoom">deepzoom</a></td>
         <td>Perl utility</td>
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
@@ -23,12 +23,12 @@
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
     <tr>
-        <td><a href="http://www.microsoft.com/en-us/download/details.aspx?id=24819">Deep Zoom Composer</a></td>
+        <td><a href="https://www.microsoft.com/en-us/download/details.aspx?id=24819">Deep Zoom Composer</a></td>
         <td>desktop app for Windows</td>
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
     <tr>
-        <td><a href="http://blogs.msdn.com/b/expression/archive/2008/11/26/hello-deepzoomtools-dll-deep-zoom-image-tile-generation-made-easy.aspx">DeepZoomTools.dll</a></td>
+        <td><a href="https://docs.microsoft.com/en-us/archive/blogs/expression/hello-deepzoomtools-dll-deep-zoom-image-tile-generation-made-easy">DeepZoomTools.dll</a></td>
         <td>.NET library, comes with Deep Zoom Composer</td>
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
@@ -48,7 +48,7 @@
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
     <tr>
-        <td><a href="http://research.microsoft.com/en-us/um/redmond/projects/ice/">Image Composite Editor</a></td>
+        <td><a href="https://www.microsoft.com/en-us/research/product/computational-photography-applications/image-composite-editor/">Image Composite Editor</a></td>
         <td>panoramic image stitcher from Microsoft Research for the Windows desktop</td>
         <td><a href="/examples/tilesource-dzi/">DZI</a></td>
     </tr>
@@ -101,17 +101,17 @@
         <td colspan="3"><h4>IIIF</h4></td>
     </tr>
     <tr>
-        <td><a href="https://medusa-project.github.io/cantaloupe/">Cantaloupe</a></td>
+        <td><a href="https://cantaloupe-project.github.io/">Cantaloupe</a></td>
         <td>Server</td>
         <td><a href="/examples/tilesource-iiif/">IIIF</a></td>
     </tr>
     <tr>
-        <td><a href="http://iipimage.sourceforge.net/">IIPImage</a></td>
+        <td><a href="https://iipimage.sourceforge.io/">IIPImage</a></td>
         <td>Server</td>
         <td><a href="/examples/tilesource-iiif/">IIIF</a></td>
     </tr>
     <tr>
-        <td><a href="http://kakadusoftware.com">Kakadu</a></td>
+        <td><a href="https://kakadusoftware.com/">Kakadu</a></td>
         <td>
             C++ library to encode or decode JPEG 2000 images
             <br><br>
@@ -134,12 +134,12 @@
         <td colspan="3"><h4>TMS</h4></td>
     </tr>
     <tr>
-        <td><a href="http://www.gdal.org/gdal2tiles.html">GDAL2tiles</a></td>
+        <td><a href="https://gdal.org/gdal2tiles.html">GDAL2tiles</a></td>
         <td>Python</td>
         <td><a href="/examples/tilesource-tms/">TMS</a></td>
     </tr>
     <tr>
-        <td><a href="http://www.maptiler.org/">MapTiler</a></td>
+        <td><a href="https://www.maptiler.org/">MapTiler</a></td>
         <td>desktop app for Windows, Mac, Linux</td>
         <td><a href="/examples/tilesource-tms/">TMS</a></td>
     </tr>


### PR DESCRIPTION
This pull request updates the URLs of some of the third party projects that are listed on the [Creating Zooming Images](https://openseadragon.github.io/examples/creating-zooming-images/) page.

A brief summary of the changes:
- `http://` has been changed to `https://` where available.
- Links that respond with Moved Permanently (HTTP 301) have been updated to their new location.
- Links that respond with Not Found (HTTP 404) have been updated to their new location.
