### PR TITLE
Documment events in overlays.

### DIFF
--- a/www/ui-overlays.html
+++ b/www/ui-overlays.html
@@ -816,3 +816,55 @@ var viewer = OpenSeadragon({
 });
 </pre>
 </div>
+
+
+<div class="description">
+    <h3>Overlays and events</h3>
+    <p>
+        Events fired on elements hidden inside elements that are part
+        of the viewer are managed by <code>MouseTracker</code> system.
+        Trying to use vanilla JS or other utilities such as jQuery will
+        fail.
+    </p>
+</div>
+<div class="demoarea">
+<script type="text/javascript">
+    rotationViewer.addHandler('open', () => {
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('overlay-rotation-exact'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('right-arrow-overlay-no-rotate'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('overlay-rotation-bounding-box'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+    });
+</script>
+Try to click on the overlay in the above example.
+<pre>
+    viewer.addHandler('open', () => {
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('overlay-rotation-exact'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('right-arrow-overlay-no-rotate'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+        new OpenSeadragon.MouseTracker({
+            element: document.getElementById('overlay-rotation-bounding-box'),
+            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        });
+    });
+</pre>
+</div>

--- a/www/ui-overlays.html
+++ b/www/ui-overlays.html
@@ -785,6 +785,27 @@ document.querySelector('#toggle-overlay').addEventListener('click', function() {
                 rotationViewer.viewport.setRotation(ui.value);
             }
         });
+
+        //this is code for the next 'Overlays and events' example,
+        // adding it to a separate script tag made some browser
+        // not to fire this correctly unless dev settings were opened
+        rotationViewer.addHandler('open', () => {
+            new OpenSeadragon.MouseTracker({
+                element: document.getElementById('overlay-rotation-exact'),
+                clickHandler: e => alert('Element selected! ' + e.originalEvent.target.id),
+                contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
+            });
+            new OpenSeadragon.MouseTracker({
+                element: document.getElementById('right-arrow-overlay-no-rotate'),
+                clickHandler: e => alert('Element selected! ' + e.originalEvent.target.id),
+                contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
+            });
+            new OpenSeadragon.MouseTracker({
+                element: document.getElementById('overlay-rotation-bounding-box'),
+                clickHandler: e => alert('Element selected! ' + e.originalEvent.target.id),
+                contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
+            });
+        });
     </script>
     </div>
 
@@ -828,43 +849,24 @@ var viewer = OpenSeadragon({
     </p>
 </div>
 <div class="demoarea">
-<script type="text/javascript">
-    rotationViewer.addHandler('open', () => {
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('overlay-rotation-exact'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('right-arrow-overlay-no-rotate'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('overlay-rotation-bounding-box'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
-    });
-</script>
-Try to click on the overlay in the above example.
+Click on any overlay in the "Rotation" example above.
 <pre>
-    viewer.addHandler('open', () => {
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('overlay-rotation-exact'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('right-arrow-overlay-no-rotate'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
-        new OpenSeadragon.MouseTracker({
-            element: document.getElementById('overlay-rotation-bounding-box'),
-            pressHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-            contextMenuHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
-        });
+viewer.addHandler('open', () => {
+    new OpenSeadragon.MouseTracker({
+        element: document.getElementById('overlay-rotation-exact'),
+        clickHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
     });
+    new OpenSeadragon.MouseTracker({
+        element: document.getElementById('right-arrow-overlay-no-rotate'),
+        clickHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
+    });
+    new OpenSeadragon.MouseTracker({
+        element: document.getElementById('overlay-rotation-bounding-box'),
+        clickHandler: e => alert('Element clicked! ' + e.originalEvent.target.id),
+        contextMenuHandler: e => alert('Context menu fired! ' + e.originalEvent.target.id),
+    });
+});
 </pre>
 </div>


### PR DESCRIPTION
The issue https://github.com/openseadragon/openseadragon/issues/2263 led me to this PR since it was certainly missing. I re-used the previous example as a closest because I felt creating one more viewer for it was pointless and put only too much content on a single page.