### PR TITLE
Remove defunct link to "Zoosphere" from in-the-wild

### DIFF
--- a/www/in-the-wild.html
+++ b/www/in-the-wild.html
@@ -401,7 +401,6 @@
              <li>e.g. <a href="http://heatmaps.nimblex.net/tiles/400-500-Bucharest-Feb-2017.html">400 MHz - 500 MHz</a></li>
          </ul>
      </li>
-    <li><a href="http://www.zoosphere.net/">ZooSphere</a></li>
 </ul>
 <h4><a name="storytelling"></a>Storytelling/Media</h4>
 <ul class="square-list">


### PR DESCRIPTION
"Zoosphere" redirects to a gambling site now, so it shouldn't be included in the in-the-wild link list.