### PR TITLE
Index: Fix dead link to GeoTIFFTileSource demo

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -87,7 +87,7 @@
         </p>
         <ul>
             <li>
-                <a href="https://pearcetm.github.io/GeoTIFFTileSource/demo.html">
+                <a href="https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html">
                     GeoTIFFTileSource - view TIFF-compatible files via geotiff.js
                 </a>
             </li>


### PR DESCRIPTION
https://pearcetm.github.io/GeoTIFFTileSource/demo.html is now
https://pearcetm.github.io/GeoTIFFTileSource/demo/demo.html