### PR TITLE
Added Doodle plugin

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -196,6 +196,7 @@
     <li>
         <h3>Code Plugins</h3>
         <ul class="square-list">
+            <li><a href="https://github.com/WT-SML/doodle">Doodle</a> allows you to draw graphics on image, and it performs extremely well and is able to create 100,000 interactive shapes.</li>
             <li><a href="https://github.com/Emigre/openseadragon-annotations">OpenSeadragonAnnotations</a> allows you to draw in a SVG overlay that scales with the image. Useful to annotate and highlight regions of an image.</li>
             <li><a href="https://github.com/recogito/annotorious-openseadragon">OpenSeadragonAnnotorious</a> enables creation and display of annotations in W3C Web Annotation format.</li>
             <li><a href="https://github.com/openseadragon/bookmark-url">Bookmark URL</a> updates the page URL with the current zoom/pan.</li>


### PR DESCRIPTION
这是一个注重性能的插件。尽管官方插件列表已经有了类似的实现。但本插件支持的形状数量高出好多个数量级。它在病理学细胞图像的标注上起着至关重要的作用，因为这类图像上通常有十几万的细胞。本插件用了一系列性能优化算法，使得在形状数量巨大的情况下，每个形状仍然支持交互。